### PR TITLE
Fix jQuery require naming conflict

### DIFF
--- a/src/main/webapp/jquery.js
+++ b/src/main/webapp/jquery.js
@@ -1,5 +1,5 @@
 jqmng.define('jquery', function() {
-    if (typeof $ !== "undefined") {
-        return $;
+    if (typeof jQuery !== "undefined") {
+        return jQuery;
     }
 });


### PR DESCRIPTION
Made it so jQuery require returns jQuery variable instead of $, to avoid conflicts with other libraries that use $.
