### PR TITLE
Issue with option directive generating 'undefined' JS error

### DIFF
--- a/src/integration/option.js
+++ b/src/integration/option.js
@@ -10,12 +10,17 @@
                     valueInterpolateFn = $interpolate(tElement.attr('value'), true);
                 }
                 return function (scope, iElement, iAttrs) {
-                    scope.$watch(textInterpolateFn, function () {
-                        iElement.trigger("$childrenChanged");
-                    });
-                    scope.$watch(valueInterpolateFn, function () {
-                        iElement.trigger("$childrenChanged");
-                    });
+                    if (textInterpolateFn != null) {
+                        scope.$watch(textInterpolateFn, function () {
+                            iElement.trigger("$childrenChanged");
+                        });
+                    }
+
+                    if (valueInterpolateFn != null) {
+                        scope.$watch(valueInterpolateFn, function () {
+                            iElement.trigger("$childrenChanged");
+                        });
+                    }
                 };
             }
         };


### PR DESCRIPTION
I was finding that there was a undefined error on the $watch call, because the $interpolate was returning null. (i.e. no expression to interpolate).

This PR should fix that.
